### PR TITLE
macOS screenshare fix

### DIFF
--- a/Sources/Agora-Video-UIKit/AgoraUIKit.swift
+++ b/Sources/Agora-Video-UIKit/AgoraUIKit.swift
@@ -22,7 +22,7 @@ public struct AgoraUIKit: Codable {
     /// Framework type of UIKit. "native", "flutter", "reactnative"
     public fileprivate(set) var framework: String
     /// Version of UIKit being used
-    public static let version = "4.0.3"
+    public static let version = "4.0.4"
     /// Framework type of UIKit. "native", "flutter", "reactnative"
     public static let framework = "native"
     #if os(iOS)

--- a/Sources/Agora-Video-UIKit/AgoraVideoViewer+VideoControl.swift
+++ b/Sources/Agora-Video-UIKit/AgoraVideoViewer+VideoControl.swift
@@ -167,26 +167,39 @@ extension AgoraVideoViewer {
         #elseif os(macOS)
         ssButton.layer?.backgroundColor = (ssButton.isOn ? NSColor.systemGreen : NSColor.systemGray).cgColor
         if ssButton.isOn { self.startSharingScreen()
-        } else { self.agkit.stopScreenCapture() }
+        } else { self.stopSharingScreen() }
         #endif
     }
 
+    #if os(macOS)
     /// Start a new screen capture (macOS only for now)
     /// - Parameter displayId: The display ID of the screen to be shared. This parameter specifies which screen you want to share.
     /// - Parameter contentHint: The content hint for screen sharing, see [AgoraVideoContentHint](https://docs.agora.io/en/Interactive%20Broadcast/API%20Reference/oc/Constants/AgoraVideoContentHint.html?platform=macOS).
     ///
     /// <br>For information on how to get the displayId, see [Share the Screen](https://docs.agora.io/en/Video/screensharing_mac?platform=macOS)
-    @objc open func startSharingScreen(displayId: UInt = 0) { // , contentHint: AgoraVideoContentHint = .none) {
-        #if os(macOS)
-        let rectangle = CGRect.zero
+    @objc open func startSharingScreen(displayId: UInt = 0) {
         let parameters = AgoraScreenCaptureParameters()
-        parameters.dimensions = CGSize.zero
+        parameters.dimensions = CGSize(width: 640, height: 480)
         parameters.frameRate = 15
         parameters.bitrate = 1000
         parameters.captureMouseCursor = true
-        self.agkit.startScreenCapture(byDisplayId: UInt32(displayId), regionRect: rectangle, captureParams: parameters)
-        #endif
+        self.agkit.startScreenCapture(
+            byDisplayId: UInt32(displayId), regionRect: CGRect.zero, captureParams: parameters
+        )
+        let mediaOptions = AgoraRtcChannelMediaOptions()
+        mediaOptions.publishCameraTrack = false
+        mediaOptions.publishScreenTrack = true
+        self.agkit.updateChannel(with: mediaOptions)
     }
+
+    func stopSharingScreen() {
+        self.agkit.stopScreenCapture()
+        let mediaOptions = AgoraRtcChannelMediaOptions()
+        mediaOptions.publishCameraTrack = true
+        mediaOptions.publishScreenTrack = false
+        self.agkit.updateChannel(with: mediaOptions)
+    }
+    #endif
 
     /// Turn on/off the 'beautify' effect. Visual and voice change.
     @objc open func toggleBeautify() {

--- a/Sources/Agora-Video-UIKit/AgoraVideoViewer+VideoControl.swift
+++ b/Sources/Agora-Video-UIKit/AgoraVideoViewer+VideoControl.swift
@@ -174,9 +174,9 @@ extension AgoraVideoViewer {
     #if os(macOS)
     /// Start a new screen capture (macOS only for now)
     /// - Parameter displayId: The display ID of the screen to be shared. This parameter specifies which screen you want to share.
-    /// - Parameter contentHint: The content hint for screen sharing, see [AgoraVideoContentHint](https://docs.agora.io/en/Interactive%20Broadcast/API%20Reference/oc/Constants/AgoraVideoContentHint.html?platform=macOS).
     ///
-    /// <br>For information on how to get the displayId, see [Share the Screen](https://docs.agora.io/en/Video/screensharing_mac?platform=macOS)
+    ///  To search for your desired screen, or list them, use [AgoraRtcEngineKit.getScreenCaptureSources](https://api-ref.agora.io/en/voice-sdk/macos/4.x/API/class_irtcengine.html#api_irtcengine_getscreencapturesources).
+    /// <br>For information on how to get the displayId, see [Share the Screen](https://docs.agora.io/en/video-calling/develop/product-workflow?platform=macos)
     @objc open func startSharingScreen(displayId: UInt = 0) {
         let parameters = AgoraScreenCaptureParameters()
         parameters.dimensions = CGSize(width: 640, height: 480)
@@ -192,7 +192,7 @@ extension AgoraVideoViewer {
         self.agkit.updateChannel(with: mediaOptions)
     }
 
-    func stopSharingScreen() {
+    @objc open func stopSharingScreen() {
         self.agkit.stopScreenCapture()
         let mediaOptions = AgoraRtcChannelMediaOptions()
         mediaOptions.publishCameraTrack = true


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/AgoraIO-Community/VideoUIKit-macOS/blob/main/CONTRIBUTING.md -->

> Release Version: 4.0.4

## Release Notes

- Fix Builtin screenshare button

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] The GitHub Actions pass building and linting. Linter returns no warnings or errors.
- [x] The QA checklist below has been completed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:

- [x] Bugfix 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Builtin screenshare wasn't working.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Builtin screenshare works

## Does this introduce a breaking change?

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- If no code has changed, remove this section -->
## QA Checklist

### UIKit Update Checklist (Minor or Patch Release)

- [x] Updated version number in `Sources/Agora-Video-UIKit/AgoraUIKit.swift`
- [x] Using the latest version of Agora's Video SDK
- [x] Example apps are all functional
- [x] Core features are still working (both ways across platforms)
	- [x] Camera + Mic muting works for local and remote users
	- [x] Users are added and removed correctly when they join and leave the channel
	- [x] Older versions of the library gracefully handle changes (Create issue if not)
	- [x] Builtin buttons all work as expected
- [x] Any newly deprecated methods are flagged as such inline and in documentation
